### PR TITLE
Split run_cmd

### DIFF
--- a/src/exceptions.py
+++ b/src/exceptions.py
@@ -5,14 +5,19 @@ class SCAutolibException(Exception):
 
 
 class NonZeroReturnCode(SCAutolibException):
-    def __init__(self, cmd=None, msg: str = "Command exited with non zero return code"):
+    def __init__(self, msg: str = "Command exited with non zero return code"):
         self.msg = msg
-        self.cmd = cmd
         super().__init__(self.msg)
 
 
 class PatternNotFound(SCAutolibException):
     def __init__(self, msg: str = "Pattern not found in the output"):
+        self.msg = msg
+        super().__init__(msg)
+
+
+class DisallowedPatternFound(SCAutolibException):
+    def __init__(self, msg: str = "Disallowed pattern found in the output"):
         self.msg = msg
         super().__init__(msg)
 


### PR DESCRIPTION
WIP: please do not merge before proper testing. 

Split run_cmd to two separate functions: 1) run_cmd that run
command with pexpect; 2) check_output that checks output of
run_cmd for presence of desired and undesired patterns.