### PR TITLE
Fix/duplicate ipa user

### DIFF
--- a/.github/workflows/scautolib-unit-test.yml
+++ b/.github/workflows/scautolib-unit-test.yml
@@ -28,4 +28,4 @@ jobs:
         run: python3 -m pip install --upgrade -I -r test/requirements.txt
 
       - name: Run unit tests
-        run: pytest test/ -sv -m "not ipa" -m "not service_restart"
+        run: pytest test/ -sv -m "not ipa and not service_restart"

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -96,13 +96,13 @@ def set_config(path, value, action="replace", type_=str):
     """Sets field to given value in configuration file.
 
     :param path: path in the configuration file in doted notation (a.b.c). If
-    any of path part doesn't exist, than it would be created.
+    any of path part doesn't exist, then it would be created.
     :param value: value to be set for last key in path
-    :param action: action for value. By default is "replace". If "append", than
+    :param action: action for value. By default, is "replace". If "append", then
     given value would be appended to the list of value for the last key in the
     path.
     :param type_: data type to which value would be converted and inserted to
-    configuration file. By default is "str".
+    configuration file. By default, is "str".
     """
     conf_path = read_env("CONF")
     with open(conf_path, "r") as file:

--- a/src/env_cli.py
+++ b/src/env_cli.py
@@ -1,5 +1,5 @@
 import click
-from SCAutolib.src import load_env
+from SCAutolib.src import load_env, set_config
 from SCAutolib.src.env import *
 
 

--- a/test/pytest.ini
+++ b/test/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
 markers =
     slow: mark test as slow.
-    service_restart: test restarts systemd service (this tests can't be executed in the container)
+    service_restart: test restarts systemd service (this tests can not be executed in the container)
     ipa: test working with FreeIPA (client or server)

--- a/test/test_env_cli.py
+++ b/test/test_env_cli.py
@@ -142,7 +142,7 @@ def test_prepare_ipa(config_file_correct, caplog, runner, ipa_ip, ipa_hostname,
 @pytest.mark.filterwarnings(
     'ignore:Unverified HTTPS request is being made to host.*')
 def test_prepare_ipa_cards(config_file_correct, caplog, runner, ipa_ip,
-                           ipa_hostname, src_path):
+                           ipa_hostname, src_path, ipa_user):
     result = runner.invoke(env_cli.prepare,
                            ["--conf", config_file_correct, "--ipa",
                             "--server-ip", ipa_ip, "--server-hostname",
@@ -172,6 +172,7 @@ def test_prepare_ipa_cards(config_file_correct, caplog, runner, ipa_ip,
         assert f'SOFTHSM2_CONF="{conf_dir}/softhsm2.conf"' in content
         assert f'WorkingDirectory = {card_dir}' in content
     finally:
+        check_output(["ipa", "user-del", ipa_user, "--no-preserve"])
         check_output(["ipa-client-install", "--uninstall", "-U"])
 
 
@@ -247,7 +248,7 @@ def test_cleanup(real_factory, loaded_env, caplog, runner, clean_conf,
     assert not exists(src_file_not_bakcup)
 
     # User is correctly deleted
-    assert f"User {test_user} is removed." in caplog.messages
+    assert f"Local user {test_user['name']} is removed." in caplog.messages
     with pytest.raises(KeyError):
         pwd.getpwnam('test-name')
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -53,7 +53,7 @@ def test_run_cmd_simple_cmd():
 
 
 def test_run_cmd_login_root_with_passwd(test_user):
-    output = utils.run_cmd(f"su {test_user}  -c 'su - -c whoami'",
+    output = utils.run_cmd(f"su {test_user['name']}  -c 'su - -c whoami'",
                            pin=False, passwd="redhat")
     assert "root" in output
     assert "RC:0" in output
@@ -61,7 +61,7 @@ def test_run_cmd_login_root_with_passwd(test_user):
 
 def test_run_cmd_pattern_not_found_password(test_user):
     with pytest.raises(PatternNotFound):
-        utils.run_cmd(f"su {test_user}  -c 'su - -c whoami'",
+        utils.run_cmd(f"su {test_user['name']}  -c 'su - -c whoami'",
                       pin=True, passwd="redhat")
 
 


### PR DESCRIPTION
Closes #42

Original idea was to randomize IPA users if provided username already exists on the IPA server. We decided to leave specifying unique username on the user and return an error if there is a duplicate user on the IPA server. 