### PR TITLE
Update tox environments: add env for generating coverage

### DIFF
--- a/.github/workflows/scautolib-unit-test.yml
+++ b/.github/workflows/scautolib-unit-test.yml
@@ -21,4 +21,4 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Unit tests
-        run: tox -e pytest
+        run: tox -e ci

--- a/tox.ini
+++ b/tox.ini
@@ -9,12 +9,23 @@ set_env = PYTHONPATH=.
 deps = flake8
 commands = flake8 SCAutolib/ test/ setup.py
 
-[testenv:pytest]
+[testenv:ci]
 deps =
     -rrequirements.txt
     pytest
 commands = pytest test/ -sv -m "not ipa and not service_restart" {posargs}
 
+[testenv:all-tests]
+deps =
+    {[testenv:ci]deps}
+    pytest-env
+commands = pytest test/ {posargs}
+
+[testenv:coverage]
+deps =
+    {[testenv:all-tests]deps}
+    pytest-cov
+commands = pytest --cov-report html:coverage --cov=SCAutolib test/ {posargs}
 
 [flake8]
 exclude =


### PR DESCRIPTION
For better development experience, I've added a new tox environment for generating coverage reports in HTML. So now full library test coverage can be generated with `tox -e coverage` and _coverage_ directory would be created in project root dir. To view the report, open _coverage/index.html_ in the browser.

Also, to have "one-shot execution" of all unit tests through tox similarly to how we do in CI, a new env is added for running all available tests. This env is not guaranteed to run properly in CI mainly due to uni tests that require IPA server (now is not available in CI)