### PR TITLE
File class improvements

### DIFF
--- a/SCAutolib/models/file.py
+++ b/SCAutolib/models/file.py
@@ -76,7 +76,11 @@ class File:
     def set(self, key: str, value: Union[int, str, bool], section: str = None,
             separator: str = "="):
         """
-        Modify value in config file.
+        Modify value in config file. Modification is made through the
+        ConfigParser object if it is defined. If not, then key value pair
+        would be written to the file through normal `write()` method with
+        composed string in the following form `<key><separator><value>` (spaces
+        around key has to be specified as a part of the `separator` parameter).
 
         :param key: value for this key will be updated
         :type key: str
@@ -84,9 +88,8 @@ class File:
         :type value: int or str or bool
         :param section: section of config file that will be modified
         :type section: str
-        :param separator: separator that would be used in files that is not
-            supported by configparser. It would be used to separate a key and a
-            value
+        :param separator: Character to be used as a separator between key and
+            value in files that are not supported by ConfigParser object.
         :type separator: str
 
         """
@@ -136,25 +139,28 @@ class File:
 
     def get(self, key, section: str = None, separator: str = "="):
         """
-        Method would return the value of the key in section (if set). If the
-        file do not support sections (section for this method is not provided),
-        then file would be parsed in a simple way with `.readlines()` method and
-        using separator each line would be split into two parts: key and a
-        value. If key is matched, the value is striped and returned.
+        Method processes and return the value of the key in section. If the
+        section is not provided (section=None), then file would parsed line by
+        line splitting the line on separator. First match wins and returned.
 
-        If file supports section (can be parsed via configparser), then section
-        (in this case has to be set) and key would be used for accessing the
-        value.
+        If section is provided and the file can be parsed by the ConfigParser,
+        then this object would be used to look for the key.
 
-        In both cases, if key is not found, an exception would be raised:
-        SCAutolib.SCAutolibException for no-configparser files, and for
+        The exception is raised if the key is not found.
+
+         for no-configparser files, and for
         configparser some of its exceptions.
         :param key: required key
         :param section: section where the key should be found
         :param separator: applicable only for non-configparser file. Separator
             that would be used to so split a line from the file. By default
             separator is '='
-
+        :raise SCAutolib.SCAutolibException: if the key is not found the
+            non-ConfigParser file
+        :raise configparser.NoSectionError: if the section is not found in
+            ConfigParser-supported file
+        :raise KeyError: if the key is not present in ConfigParser-supported
+            file
         :return: value of the key in section (if set)
         """
         if section is None:

--- a/SCAutolib/models/file.py
+++ b/SCAutolib/models/file.py
@@ -345,7 +345,7 @@ class SSSDConf(File):
                 self._changes.optionxform = str
         os.chmod(self._conf_file, 0o600)
 
-    def clean(self):
+    def restore(self):
         """
         Removes sssd.conf file in case it was created by this package or
         restore original sssd.conf in case the file was modified.
@@ -358,10 +358,9 @@ class SSSDConf(File):
         #  required attributes in JSON format load() method that would be used
         #  in other then setup runtimes to restore (load from JSON) all
         #  attributes of this object
+        self.clean()
         if self._backup_original:
             copy2(self._backup_original, self._conf_file)
-        else:
-            self._conf_file.unlink()
 
     def update_default_content(self):
         """

--- a/SCAutolib/models/file.py
+++ b/SCAutolib/models/file.py
@@ -140,17 +140,14 @@ class File:
 
     def get(self, key, section: str = None, separator: str = "="):
         """
-        Method processes and return the value of the key in section. If the
-        section is not provided (section=None), then file would parsed line by
-        line splitting the line on separator. First match wins and returned.
+        Method processes and returns the value of the key in section. If the
+        section is not provided (section=None), then file would be parsed line
+        by line splitting the line on separator. First match wins and is
+        returned.
 
         If section is provided and the file can be parsed by the ConfigParser,
         then this object would be used to look for the key.
 
-        The exception is raised if the key is not found.
-
-         for no-configparser files, and for
-        configparser some of its exceptions.
         :param key: required key
         :param section: section where the key should be found
         :param separator: applicable only for non-configparser file. Separator
@@ -291,8 +288,6 @@ class SSSDConf(File):
             with self._conf_file.open() as config:
                 self._default_parser.read_file(config)
             logger.info(f"{self._conf_file} file exists, loading values")
-            logger.info(f"Backing up {self._conf_file}"
-                        f"as {self._backup_original}")
             self._backup_original = self.backup("original")
 
         except FileNotFoundError:

--- a/SCAutolib/models/file.py
+++ b/SCAutolib/models/file.py
@@ -13,13 +13,14 @@ basic operations on config files defined in this module:
     clean:  remove config file; note that some child classes may also restore
             original config file if backup exists.
 """
+import os
 from configparser import ConfigParser
 from pathlib import Path
 from shutil import copy2
 from typing import Union
 
-from SCAutolib import TEMPLATES_DIR, LIB_BACKUP
-from SCAutolib import logger
+from SCAutolib import logger, TEMPLATES_DIR, LIB_BACKUP
+from SCAutolib.exceptions import SCAutolibException
 
 
 class File:
@@ -53,6 +54,10 @@ class File:
         if template is not None:
             self._template = Path(template)
 
+    @property
+    def path(self):
+        return self._conf_file
+
     def create(self):
         """
         Populate internal parser object with content based on template.
@@ -68,7 +73,8 @@ class File:
             with self._template.open() as t:
                 self._default_parser.read_file(t)
 
-    def set(self, key: str, value: Union[int, str, bool], section: str = None):
+    def set(self, key: str, value: Union[int, str, bool], section: str = None,
+            separator: str = "="):
         """
         Modify value in config file.
 
@@ -78,6 +84,11 @@ class File:
         :type value: int or str or bool
         :param section: section of config file that will be modified
         :type section: str
+        :param separator: separator that would be used in files that is not
+            supported by configparser. It would be used to separate a key and a
+            value
+        :type separator: str
+
         """
         if section is None:
             # simple config files without sections
@@ -92,7 +103,7 @@ class File:
                     new_content.append(line)
                     continue
                 try:
-                    conf_key, conf_val = line.split("=", 1)
+                    conf_key, conf_val = line.split(separator, 1)
                 except ValueError:
                     raise ValueError(f"unexpected format of line: {line}")
                 if conf_key.strip() == key:
@@ -101,7 +112,7 @@ class File:
                 else:
                     new_content.append(line)
             if not modified:
-                new_content.append(f"\n{key}={value}")
+                new_content.append(f"\n{key}{separator}{value}")
             self._simple_content = new_content
         else:
             # configparser compatible config files (with sections)
@@ -123,6 +134,48 @@ class File:
             logger.debug(f"Old value in section [{section}] {key}={previous}")
             logger.debug(f"New value in section [{section}] {key}={value}")
 
+    def get(self, key, section: str = None, separator: str = "="):
+        """
+        Method would return the value of the key in section (if set). If the
+        file do not support sections (section for this method is not provided),
+        then file would be parsed in a simple way with `.readlines()` method and
+        using separator each line would be split into two parts: key and a
+        value. If key is matched, the value is striped and returned.
+
+        If file supports section (can be parsed via configparser), then section
+        (in this case has to be set) and key would be used for accessing the
+        value.
+
+        In both cases, if key is not found, an exception would be raised:
+        SCAutolib.SCAutolibException for no-configparser files, and for
+        configparser some of its exceptions.
+        :param key: required key
+        :param section: section where the key should be found
+        :param separator: applicable only for non-configparser file. Separator
+            that would be used to so split a line from the file. By default
+            separator is '='
+
+        :return: value of the key in section (if set)
+        """
+        if section is None:
+            # simple config files without sections
+            if self._simple_content is None:
+                with self._conf_file.open() as config:
+                    self._simple_content = config.readlines()
+            for line in self._simple_content:
+                key_from_file, value = line.split(separator, maxsplit=1)
+                if key_from_file == key:
+                    return value.strip()
+
+            raise SCAutolibException(f"Key '{key}' doesn't present in the "
+                                     f"file {self._conf_file}")
+        elif self._default_parser is None:
+            self._default_parser = ConfigParser()
+            self._default_parser.optionxform = str
+            with self._conf_file.open() as config:
+                self._default_parser.read_file(config)
+        return self._default_parser[section][key]
+
     def save(self):
         """
         Save content of config file stored in parser object to config file.
@@ -143,6 +196,12 @@ class File:
             logger.info(f"Removing {self._conf_file}.")
         except FileNotFoundError:
             logger.info(f"{self._conf_file} does not exist. Nothing to do.")
+
+    def backup(self):
+        new_name = f"{self._conf_file.name}.backup"
+        new_path = LIB_BACKUP.joinpath(new_name)
+        copy2(self._conf_file, new_path)
+        logger.debug(f"File {self._conf_file} is stored to {new_path}")
 
 
 class SSSDConf(File):
@@ -261,6 +320,7 @@ class SSSDConf(File):
                 # to empty parser object
                 self._changes = ConfigParser()
                 self._changes.optionxform = str
+        os.chmod(self._conf_file, 0o600)
 
     def clean(self):
         """

--- a/SCAutolib/models/file.py
+++ b/SCAutolib/models/file.py
@@ -198,10 +198,21 @@ class File:
             logger.info(f"{self._conf_file} does not exist. Nothing to do.")
 
     def backup(self):
+        """
+        Save original file to the backup directory with
+        """
         new_name = f"{self._conf_file.name}.backup"
         new_path = LIB_BACKUP.joinpath(new_name)
         copy2(self._conf_file, new_path)
         logger.debug(f"File {self._conf_file} is stored to {new_path}")
+
+    def restore(self):
+        """
+        Copies backup file to original file location.
+        """
+        backup_path = LIB_BACKUP.joinpath(f"{self._conf_file.name}.backup")
+        copy2(backup_path, self._conf_file)
+        logger.debug(f"File {backup_path} is restored to {self._conf_file}")
 
 
 class SSSDConf(File):


### PR DESCRIPTION
Changes in File class bring to general File several new/updates old methods:
- `get` tries to get the value from the file using section (if set), key and separator (by default separator is `=`)
- `set` add a separator to the general File method 
- `backup` simple backup of the file
- `restore` simple restore method - copy backup file to the original place. 