### PR TITLE
Add user factory function for using in tests

### DIFF
--- a/SCAutolib/utils.py
+++ b/SCAutolib/utils.py
@@ -142,11 +142,15 @@ def user_factory(username):
     :rtype: BaseUser
     """
     user_file = LIB_DUMP_USERS.joinpath(f"{username}.json")
+    logger.debug(f"Loading user {username} from {user_file}")
     result = None
+    user = None
     if user_file.exists():
         result = BaseUser.load(user_file)
     if type(result) == tuple:
-        card_file = result[1]
-        user = result[0]
+        user, card_file = result
+        logger.debug(f"Loading card from {card_file}")
         user.card = Card.load(card_file, user=user)
-    return result
+    else:
+        user = result
+    return user

--- a/SCAutolib/utils.py
+++ b/SCAutolib/utils.py
@@ -10,8 +10,10 @@ from cryptography.hazmat.primitives.asymmetric import rsa
 from enum import Enum
 from pathlib import Path
 
-from SCAutolib import run, logger, TEMPLATES_DIR
+from SCAutolib import run, logger, TEMPLATES_DIR, LIB_DUMP_USERS
 from SCAutolib.exceptions import SCAutolibException
+from SCAutolib.models.card import Card
+from SCAutolib.models.user import BaseUser
 
 
 class OSVersion(Enum):
@@ -126,3 +128,25 @@ def dump_to_json(obj):
     with obj.dump_file.open("w") as f:
         json.dump(obj.__dict__, f)
     logger.debug(f"Object {type(obj)} is stored to the {obj.dump_file} file")
+
+
+def user_factory(username):
+    """
+    Load user with given username from JSON file. If user have the card file
+    linked, then load it as well.
+
+    :param username: username of the user
+    :type username: str
+
+    :return: user object
+    :rtype: BaseUser
+    """
+    user_file = LIB_DUMP_USERS.joinpath(f"{username}.json")
+    result = None
+    if user_file.exists():
+        result = BaseUser.load(user_file)
+    if type(result) == tuple:
+        card_file = result[1]
+        user = result[0]
+        user.card = Card.load(card_file, user=user)
+    return result

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,0 +1,13 @@
+from shutil import copy
+
+from SCAutolib import utils, LIB_DUMP_USERS
+
+
+def test_user_factory(local_user, tmp_path):
+    utils.dump_to_json(local_user)
+    utils.dump_to_json(local_user.card)
+    copy(local_user.dump_file, LIB_DUMP_USERS.joinpath(
+        f"{local_user.username}.json"))
+
+    user = utils.user_factory(local_user.username)
+    assert user


### PR DESCRIPTION
Add user factory function that would be used in tests. This factory would generate (load from JSON) the user with requires a username and returns a new instance of the BaseUser object.

Code usage example:
```python3
@pytest.mark.parametrize("user", [user_factory("local-user"), user_factory("ipa-user")], scope="session")  # <-------------------------
def test_su_login_with_sc(user, user_shell):
    with Authselect(required=False):
        with user.card(insert=True):
            cmd = f'su {user.username} -c "whoami"'
            user_shell.sendline(cmd)
            user_shell.expect(f"PIN for {user.username}:")
            user_shell.sendline(user.pin)
            user_shell.expect(user.username)
```