### PR TITLE
V2 sssd fixes

### DIFF
--- a/SCAutolib/controller.py
+++ b/SCAutolib/controller.py
@@ -240,6 +240,7 @@ class Controller:
                 key="matchrule",
                 value=f"<SUBJECT>.*CN={new_user.username}.*")
             self.sssd_conf.save()
+            run(["systemctl", "restart", "sssd"])
             logger.debug(f"Match rule for user {new_user.username} is added "
                          f"to /etc/sssd/sssd.conf")
         else:

--- a/SCAutolib/models/file.py
+++ b/SCAutolib/models/file.py
@@ -17,7 +17,6 @@ import os
 from configparser import ConfigParser
 from pathlib import Path
 from shutil import copy2
-from time import sleep
 from traceback import format_exc
 from typing import Union
 
@@ -296,7 +295,8 @@ class SSSDConf(File):
 
     def __exit__(self, exc_type, exc_value, traceback):
         if self._changed:
-            self.restore()
+            copy2(self._backup_default, self._conf_file)
+            self._changed = False
         if exc_type is not None:
             logger.error("Exception in virtual smart card context")
             logger.error(format_exc())
@@ -384,9 +384,11 @@ class SSSDConf(File):
         #  required attributes in JSON format load() method that would be used
         #  in other then setup runtimes to restore (load from JSON) all
         #  attributes of this object
-        self.clean()
+
         if self._backup_original:
             copy2(self._backup_original, self._conf_file)
+        else:
+            self.clean()
         self._changed = False
 
     def update_default_content(self):

--- a/SCAutolib/models/file.py
+++ b/SCAutolib/models/file.py
@@ -335,8 +335,6 @@ class SSSDConf(File):
         :param section: section of config file to be created/updated
         :type section: str
         """
-        self._changed = True
-
         if len(self._changes.sections()) == 0:
             self._changes.read_dict(self._default_parser)
 
@@ -346,8 +344,14 @@ class SSSDConf(File):
             self._changes.add_section(section)
 
         previous = self._changes.get(section, key, fallback="Not set")
+        if previous == value:
+            logger.info(f"A key '{key}' in section '{section}' is already set "
+                        f"to {value}. No changes in SSSD are required.")
+            return
 
         self._changes.set(section, key, value)
+        self._changed = True
+
         logger.info(f"Value is changed in section {self._changes[section]}")
         logger.debug(f"Old value in section [{section}] {key}={previous}")
         logger.debug(f"New value in section [{section}] {key}={value}")
@@ -375,6 +379,8 @@ class SSSDConf(File):
         """
         Removes sssd.conf file in case it was created by this package or
         restore original sssd.conf in case the file was modified.
+
+        .. note: SSSD service restart is caller's responsibility.
         """
 
         # FIXME: this implementation would not work in real usage. When setup

--- a/test/test_sssd_conf.py
+++ b/test/test_sssd_conf.py
@@ -153,3 +153,23 @@ def test_save_reset_parser(sssd_test_prepare):
     sssd_test.save()
     assert sssd_test._conf_file.exists()
     assert len(sssd_test._changes.sections()) == 0
+
+
+def test_context_manager(tmpdir, sssd_test_prepare):
+    """
+    Test that context manager works as expected
+    """
+    call_key, call_value, call_section = "testkey", "testvalue", "testsection"
+    sssd_test_prepare._backup_original.touch(exist_ok=True)
+
+    with sssd_test_prepare(key=call_key, value=call_value, section=call_section):
+        parser = ConfigParser()
+        with sssd_test_prepare._conf_file.open() as config:
+            parser.read_file(config)
+        assert parser.get(call_section, call_key) == call_value
+
+    with sssd_test_prepare._conf_file.open() as config:
+        parser = ConfigParser()
+        parser.read_file(config)
+        with pytest.raises(configparser.NoSectionError):
+            parser.get(call_section, call_key)

--- a/test/test_sssd_conf.py
+++ b/test/test_sssd_conf.py
@@ -155,12 +155,13 @@ def test_save_reset_parser(sssd_test_prepare):
     assert len(sssd_test._changes.sections()) == 0
 
 
+@pytest.mark.service_restart
 def test_context_manager(tmpdir, sssd_test_prepare):
     """
     Test that context manager works as expected
     """
     call_key, call_value, call_section = "testkey", "testvalue", "testsection"
-    sssd_test_prepare._backup_original.touch(exist_ok=True)
+    sssd_test_prepare._backup_default.touch(exist_ok=True)
 
     with sssd_test_prepare(key=call_key, value=call_value, section=call_section):
         parser = ConfigParser()


### PR DESCRIPTION
This PR brings another fix #107 along with functionality for using SSSD file in context manager. This feature is useful for tests when we need to make some changes in SSSD and then restore the state.
Test example:

```python
@pytest.mark.parametrize("user", [user_factory("local-user")], scope="session")
def test_su_login_p11_uri_slot_description(user, sssd, user_shell):
    """Test login with PIN to the system with p11_uri specified on specific
    slot in sssd.conf."""
    with sssd(section="pam", key="p11_uri",
              value="pkcs11:pkcs11:slot-description=Virtual%20PCD%2000%2000"):
        with Authselect(required=False), user.card(insert=True):
            cmd = f"su {user.username} -c whoami"
            user_shell.sendline(cmd)
            user_shell.expect(f"PIN for {user.username}")
            user_shell.sendline(user.pin)
            user_shell.expect(user.username)

```